### PR TITLE
Update deprecated code, dictionary size issue & fix rain sensor issue

### DIFF
--- a/custom_components/mobile_alerts/binary_sensor.py
+++ b/custom_components/mobile_alerts/binary_sensor.py
@@ -168,22 +168,33 @@ class MobileAlertesIsRainingBinarySensor(MobileAlertesBinarySensor):
     def update_data_from_sensor(self) -> None:
         """Update data from the sensor."""
         value: bool = False
-        time_span_sensor = self._coordinator.get_entity(self._sensor.measurements[2])
-        if time_span_sensor is not None:
-            time_span_sensor.add_dependent(self)
-            if time_span_sensor._attr_native_value is not None:
-                _LOGGER.debug(
-                    "is_raining time_span_sensor is not None %s %s",
-                    time_span_sensor._attr_native_value,
-                    time.ctime(time_span_sensor.last_update),
-                )
-                value = (
-                    (int(time_span_sensor._attr_native_value) == 0) and
-                    (
-                        time_span_sensor.last_update >= 
-                        time.time() - LAST_RAIN_PERIOD
+        try:
+            # Validate that measurements have enough entries
+            if len(self._sensor.measurements) <= 2:
+                _LOGGER.warning("Sensor measurements do not have enough entries.")
+                self._attr_is_on = value
+            return
+
+            # Safely retrieve the time span sensor
+            time_span_sensor = self._coordinator.get_entity(self._sensor.measurements[2])
+            if time_span_sensor is not None:
+                time_span_sensor.add_dependent(self)
+                native_value = getattr(time_span_sensor, "_attr_native_value", None)
+                last_update = getattr(time_span_sensor, "last_update", None)
+
+                if native_value is not None and isinstance(last_update, (int, float)):
+                    _LOGGER.debug(
+                        "is_raining time_span_sensor is not None %s %s",
+                        native_value,
+                        time.ctime(last_update),
                     )
-                )
+                    value = (
+                        int(native_value) == 0
+                        and last_update >= time.time() - LAST_RAIN_PERIOD
+                    )
+        except Exception as e:
+            _LOGGER.error("Error updating data from sensor: %s", e)
+
         self._attr_is_on = value
         _LOGGER.debug("is_raining update_data_from_sensor %s", self._attr_is_on)
 

--- a/custom_components/mobile_alerts/const.py
+++ b/custom_components/mobile_alerts/const.py
@@ -2,7 +2,7 @@
 
 from typing_extensions import Final
 
-from homeassistant.backports.enum import StrEnum
+from enum import StrEnum
 from mobilealerts import MeasurementType
 
 DOMAIN: Final = "mobile_alerts"

--- a/custom_components/mobile_alerts/sensor.py
+++ b/custom_components/mobile_alerts/sensor.py
@@ -409,7 +409,7 @@ class MobileAlertesPeriodRainSensor(MobileAlertesSensor):
                 )
                 self._last_update = last_rain_time
 
-        for measurement_time in self._measurements.keys():
+        for measurement_time in list(self._measurements.keys()):
             if measurement_time < (now - self._period):
                 _LOGGER.debug(
                     "period_rain update_data_from_sensor removed (%s: %s)",


### PR DESCRIPTION
These changes fixes the following issues:

binary_sensor.py: Error handling request in aiohttp.server: (original file) line 181: invalid literal for int() with base 10: '0.000000000', sometimes '4.0' instead of '0.000000000'

const.py: fixes deprecated homeassistant.backport.enum to use enum from Python 3.12 instead.

sensor.py: fixes "dictionary changed size during iteration" error for rainfall_last_hour_rain sensor.

Testing locally on two RPi 4's running HAOS: Core 2024.12.3 and OS 14.0 with no further warnings/errors.